### PR TITLE
Corrected missing return keyword in CustomValidator class

### DIFF
--- a/src/KennedyTedesco/Validation/CustomValidator.php
+++ b/src/KennedyTedesco/Validation/CustomValidator.php
@@ -52,7 +52,7 @@ class CustomValidator extends \Illuminate\Validation\Validator
             return $ruleObject->validate($value);
         }
 
-        parent::__call($method, $parameters);
+        return parent::__call($method, $parameters);
     }
 
     /**


### PR DESCRIPTION
Added missing _return_ keyword, without it all custom validations created with _Validator::extend_ will always fail.
