### PR TITLE
#6 Attempting a 'fix' for auto-loader optimisation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "respect/validation": "0.5.x"
+        "respect/validation": "0.7.x"
     },
     "require-dev": {
         "illuminate/support": ">=4.0.0",


### PR DESCRIPTION
This will pull in the latest version of Respect/Validation which will allow "composer dump-autoload -o" to be run (which is a nice thing to do when rolling code to a production environment) ;-)

I've not had a chance to test to see if there are any incompatibilities between this lib and the updated Respect one though so it may well cause more problems than it solves. ;-)

https://github.com/KennedyTedesco/Validation/issues/6