### PR TITLE
Update Respect\Validation version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "respect/validation": "0.8.0",
+        "respect/validation": "~0.8.0",
         "illuminate/support": "5.0.*@dev"
     },
     "require-dev": {


### PR DESCRIPTION
Respect\Validation uses [Semantic Versioning](http://semver.org).
With this version constraint in "composer.json" file, all bug fixes will be available on this library too.

Actually for the next `PATCH` and `MINOR` releases on Respect\Validation there will be no BC breaks, so if you prefer you can use `~0.8` instead of `~0.8.0`, since  `~0.8` will accept `>=0.8 and <1.0` and `~0.8.0` (this PR) will only accept `>=0.8.0 and <0.9`.

I chose `~0.8.0` instead because I don't want to be so aggressive.

:panda_face: 